### PR TITLE
Center align quote position

### DIFF
--- a/frameshift_extension_with_icons/styles.css
+++ b/frameshift_extension_with_icons/styles.css
@@ -17,8 +17,9 @@ body {
   font-size: 4rem;
   font-weight: 800;
   max-width: 75vw;
-  align-self: centre;
-  justify-self: start;
+  align-self: center;
+  justify-self: center;
+  text-align: center;
 }
 .pomodoro-timer {
   grid-column: 2;


### PR DESCRIPTION
Center aligns the quote element by correcting a typo and adjusting CSS properties for proper alignment.

---
<a href="https://cursor.com/background-agent?bcId=bc-880fff7c-7076-471b-a9c5-aba1a7312da9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-880fff7c-7076-471b-a9c5-aba1a7312da9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>