### PR TITLE
Center align quote on page

### DIFF
--- a/frameshift_extension_with_icons/styles.css
+++ b/frameshift_extension_with_icons/styles.css
@@ -7,22 +7,28 @@ body {
 .container {
   display: grid;
   grid-template-columns: 1fr auto;
-  grid-template-rows: auto 1fr auto;
+  grid-template-rows: 1fr auto 1fr;
   height: 100vh;
   padding: 40px;
   box-sizing: border-box;
 }
 .mental-model {
   grid-column: 1 / span 2;
+  grid-row: 2;
   font-size: 4rem;
   font-weight: 800;
   max-width: 75vw;
   align-self: center;
   justify-self: center;
   text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
 }
 .pomodoro-timer {
   grid-column: 2;
+  grid-row: 1;
   align-self: start;
   text-align: center;
 }
@@ -68,6 +74,7 @@ canvas {
 }
 .branding {
   grid-column: 2;
+  grid-row: 3;
   align-self: end;
   justify-self: end;
   font-size: 1rem;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Center aligns the quote to the middle of the page by adjusting grid layout and adding flexbox properties.

---
<a href="https://cursor.com/background-agent?bcId=bc-005aef33-83c6-4e8a-a1b2-13c1e389d51f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-005aef33-83c6-4e8a-a1b2-13c1e389d51f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>