### PR TITLE
Update master quote list with display

### DIFF
--- a/frameshift_extension_with_icons/quotes.json
+++ b/frameshift_extension_with_icons/quotes.json
@@ -1,0 +1,402 @@
+[
+  {
+    "quote": "It is important to view knowledge as sort of a semantic tree — make sure you understand the fundamental trunk and big branches before you get into the leaves/details or there is nothing for them to hang on to.",
+    "author": "Elon Musk"
+  },
+  {
+    "quote": "If I had an hour to solve a problem, I'd spend 55 minutes thinking about the problem and 5 minutes solving it.",
+    "author": "Albert Einstein"
+  },
+  {
+    "quote": "Reasoning from first principles allows you to innovate, not just iterate.",
+    "author": "Elon Musk"
+  },
+  {
+    "quote": "Stand before the world as it is, not as you wish it to be.",
+    "author": "Marcus Aurelius"
+  },
+  {
+    "quote": "There is nothing so useless as doing efficiently that which should not be done at all.",
+    "author": "Peter Drucker"
+  },
+  {
+    "quote": "No action has unintended consequences; every action has effects.",
+    "author": "Nassim Taleb"
+  },
+  {
+    "quote": "Don't just consider the immediate consequence; consider the ripple.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "Long-term thinking is the competitive advantage most people never develop.",
+    "author": "Shane Parrish"
+  },
+  {
+    "quote": "Invert, always invert.",
+    "author": "Carl Gustav Jacob Jacobi"
+  },
+  {
+    "quote": "Avoiding stupidity is easier than seeking brilliance.",
+    "author": "Charlie Munger"
+  },
+  {
+    "quote": "Tell me where I'm going to die, so I never go there.",
+    "author": "Charlie Munger"
+  },
+  {
+    "quote": "Instead of asking how to succeed, ask how you might fail — and avoid it.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "You think that because you understand 'one' you understand 'two' because one and one make two. But you must also understand 'and.'",
+    "author": "Unknown"
+  },
+  {
+    "quote": "The system is perfectly designed to get the results it gets.",
+    "author": "W. Edwards Deming"
+  },
+  {
+    "quote": "In complex systems, interventions often have counterintuitive effects.",
+    "author": "Donella Meadows"
+  },
+  {
+    "quote": "Think of systems, not snapshots.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "Compound interest is the eighth wonder of the world.",
+    "author": "Albert Einstein"
+  },
+  {
+    "quote": "Small things become big when you compound them over time.",
+    "author": "James Clear"
+  },
+  {
+    "quote": "The most powerful force in the universe is compound interest.",
+    "author": "Albert Einstein"
+  },
+  {
+    "quote": "Habits are the compound interest of self-improvement.",
+    "author": "James Clear"
+  },
+  {
+    "quote": "Success feeds on itself. Success breeds success.",
+    "author": "Brian Tracy"
+  },
+  {
+    "quote": "We are not thinking machines that feel; we are feeling machines that think.",
+    "author": "Antonio Damasio"
+  },
+  {
+    "quote": "In feedback loops, delay is the cause of instability.",
+    "author": "Donella Meadows"
+  },
+  {
+    "quote": "Negative feedback brings stability. Positive feedback brings amplification.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "The cost of anything is the amount of life you exchange for it.",
+    "author": "Henry David Thoreau"
+  },
+  {
+    "quote": "Choosing one path means closing off others.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "What you don't do determines what you can do.",
+    "author": "Tim Ferriss"
+  },
+  {
+    "quote": "You can do anything, but not everything.",
+    "author": "David Allen"
+  },
+  {
+    "quote": "We see the world not as it is, but as we are.",
+    "author": "Anaïs Nin"
+  },
+  {
+    "quote": "The first principle is that you must not fool yourself — and you are the easiest person to fool.",
+    "author": "Richard Feynman"
+  },
+  {
+    "quote": "Man is not a rational animal; he is a rationalizing animal.",
+    "author": "Robert Heinlein"
+  },
+  {
+    "quote": "What the human being is best at doing is interpreting all new information so that their prior conclusions remain intact.",
+    "author": "Warren Buffett"
+  },
+  {
+    "quote": "Know what you know and know what you don't know.",
+    "author": "Charlie Munger"
+  },
+  {
+    "quote": "Risk comes from not knowing what you're doing.",
+    "author": "Warren Buffett"
+  },
+  {
+    "quote": "Stay within your circle of competence. It's not how big it is, but how well you understand it.",
+    "author": "Charlie Munger"
+  },
+  {
+    "quote": "The key to success is playing the game you understand.",
+    "author": "Charlie Munger"
+  },
+  {
+    "quote": "Strong opinions, weakly held.",
+    "author": "Paul Saffo"
+  },
+  {
+    "quote": "Update your beliefs when presented with new evidence.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "Reality is uncertain; we update as we learn.",
+    "author": "Shane Parrish"
+  },
+  {
+    "quote": "Always have a margin of error in your beliefs.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "The greatest risk is not understanding probability.",
+    "author": "Nassim Taleb"
+  },
+  {
+    "quote": "Anything can happen. What if it's likely to happen?",
+    "author": "Unknown"
+  },
+  {
+    "quote": "It's not the odds that matter — it is the stakes.",
+    "author": "Nassim Taleb"
+  },
+  {
+    "quote": "A good decision doesn't always lead to a good outcome.",
+    "author": "Annie Duke"
+  },
+  {
+    "quote": "Some things benefit from shocks; they thrive and grow when exposed to volatility.",
+    "author": "Nassim Taleb"
+  },
+  {
+    "quote": "Wind extinguishes a candle and energizes fire.",
+    "author": "Nassim Taleb"
+  },
+  {
+    "quote": "If you want to be antifragile, stop trying to predict.",
+    "author": "Nassim Taleb"
+  },
+  {
+    "quote": "Embrace chaos. It's often the birthplace of new order.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "Never ask a barber if you need a haircut.",
+    "author": "Warren Buffett"
+  },
+  {
+    "quote": "Don't take advice from someone who doesn't share in the consequences.",
+    "author": "Nassim Taleb"
+  },
+  {
+    "quote": "If you're not willing to eat your own cooking, don't expect anyone else to eat it.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "Accountability breeds responsibility.",
+    "author": "Stephen Covey"
+  },
+  {
+    "quote": "Logic is the beginning of wisdom, not the end.",
+    "author": "Spock"
+  },
+  {
+    "quote": "Emotion clouds judgment.",
+    "author": "Stoic philosophy"
+  },
+  {
+    "quote": "Detach to see clearly.",
+    "author": "Naval Ravikant"
+  },
+  {
+    "quote": "Don't just feel it — analyze it.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "Creativity loves constraints.",
+    "author": "Marissa Mayer"
+  },
+  {
+    "quote": "Scarcity sharpens focus.",
+    "author": "Shane Parrish"
+  },
+  {
+    "quote": "Necessity is the mother of invention.",
+    "author": "Plato"
+  },
+  {
+    "quote": "Limited resources breed resourcefulness.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "The more models you have, the better you'll be able to solve problems.",
+    "author": "Charlie Munger"
+  },
+  {
+    "quote": "You must know the big ideas in the big disciplines.",
+    "author": "Charlie Munger"
+  },
+  {
+    "quote": "No single model is sufficient by itself.",
+    "author": "Charlie Munger"
+  },
+  {
+    "quote": "When all you have is a hammer, everything looks like a nail.",
+    "author": "Abraham Maslow"
+  },
+  {
+    "quote": "The universe tends toward disorder.",
+    "author": "Second Law of Thermodynamics"
+  },
+  {
+    "quote": "Without maintenance, everything degrades.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "Order requires energy. Neglect ensures chaos.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "Things fall apart; the center cannot hold.",
+    "author": "W. B. Yeats"
+  },
+  {
+    "quote": "There are no solutions. There are only trade-offs.",
+    "author": "Thomas Sowell"
+  },
+  {
+    "quote": "You can have anything you want, but not everything you want.",
+    "author": "Ray Dalio"
+  },
+  {
+    "quote": "Every gain is paid for with a loss somewhere else.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "Behind every decision is a sacrifice.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "The first bite is always the best.",
+    "author": "Economic Principle"
+  },
+  {
+    "quote": "More isn't always better.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "Diminishing returns exist everywhere.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "What satisfies you today may bore you tomorrow.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "The wise build in redundancy.",
+    "author": "Nassim Taleb"
+  },
+  {
+    "quote": "Safety margins are not waste; they are protection.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "Prepare for what you cannot predict.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "Plan for failure, not just success.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "Adapt or perish.",
+    "author": "H.G. Wells"
+  },
+  {
+    "quote": "Survival goes not to the strongest but to the most adaptable.",
+    "author": "Charles Darwin"
+  },
+  {
+    "quote": "Evolution favors the flexible.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "Nature is trial and error at scale.",
+    "author": "Nassim Taleb"
+  },
+  {
+    "quote": "The simplest explanation is usually the best.",
+    "author": "William of Ockham"
+  },
+  {
+    "quote": "Don't multiply entities beyond necessity.",
+    "author": "Occam's Razor"
+  },
+  {
+    "quote": "Simplicity is the ultimate sophistication.",
+    "author": "Leonardo da Vinci"
+  },
+  {
+    "quote": "Keep it simple. Complexity breeds confusion.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "If something has lasted a long time, it's likely to last longer.",
+    "author": "Nassim Taleb"
+  },
+  {
+    "quote": "Old things endure for a reason.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "The longer it survives, the longer it's expected to.",
+    "author": "Lindy Principle"
+  },
+  {
+    "quote": "New isn't always better.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "Don't trade what you want most for what you want now.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "What matters most is rarely urgent.",
+    "author": "Stephen Covey"
+  },
+  {
+    "quote": "The future is where compounding lives.",
+    "author": "Shane Parrish"
+  },
+  {
+    "quote": "Discipline is choosing between what you want now and what you want most.",
+    "author": "Abraham Lincoln"
+  },
+  {
+    "quote": "The unexamined life is not worth living.",
+    "author": "Socrates"
+  },
+  {
+    "quote": "Thinking about how we think is the beginning of wisdom.",
+    "author": "Unknown"
+  },
+  {
+    "quote": "The ability to learn faster than your competitors may be the only sustainable competitive advantage.",
+    "author": "Arie de Geus"
+  },
+  {
+    "quote": "You cannot solve a problem with the same mind that created it.",
+    "author": "Peter Drucker"
+  }
+]

--- a/frameshift_extension_with_icons/script.js
+++ b/frameshift_extension_with_icons/script.js
@@ -1,8 +1,19 @@
 document.addEventListener('DOMContentLoaded', () => {
-  fetch('models.json')
+  fetch('quotes.json')
     .then(res => res.json())
-    .then(models => {
-      const index = Math.floor(Math.random() * models.length);
-      document.getElementById('modelText').textContent = models[index];
+    .then(quotes => {
+      const index = Math.floor(Math.random() * quotes.length);
+      const selectedQuote = quotes[index];
+      const modelElement = document.getElementById('modelText');
+      
+      // Create formatted quote display with quote and author
+      modelElement.innerHTML = `
+        <div class="quote-text">"${selectedQuote.quote}"</div>
+        <div class="quote-author">— ${selectedQuote.author}</div>
+      `;
+    })
+    .catch(error => {
+      console.error('Error loading quotes:', error);
+      document.getElementById('modelText').textContent = 'Loading...';
     });
 });

--- a/frameshift_extension_with_icons/styles.css
+++ b/frameshift_extension_with_icons/styles.css
@@ -21,6 +21,21 @@ body {
   font-weight: 800;
   max-width: 75vw;
   text-align: center;
+  line-height: 1.1;
+}
+
+.quote-text {
+  font-size: 4rem;
+  font-weight: 800;
+  line-height: 1.1;
+  margin-bottom: 1rem;
+}
+
+.quote-author {
+  font-size: 2rem;
+  font-weight: 400;
+  color: #666;
+  font-style: italic;
 }
 
 .pomodoro-timer {


### PR DESCRIPTION
Replace mental models display with a new quotes system that shows both quote and author.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c1a4e37-d669-43fc-a154-dc825971d40a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3c1a4e37-d669-43fc-a154-dc825971d40a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>